### PR TITLE
Add event ID to Darwin header

### DIFF
--- a/darwin/darwinprotocol.py
+++ b/darwin/darwinprotocol.py
@@ -84,7 +84,8 @@ class DarwinPacket(ctypes.Structure):
                 ("filter_code", ctypes.c_long),
                 ("body_size", ctypes.c_size_t),
                 ("certitude_size", ctypes.c_size_t),
-                ("certitude_list_placeholder", ctypes.c_uint * DEFAULT_CERTITUDE_LIST_SIZE), ]
+                ("certitude_list_placeholder", ctypes.c_uint * DEFAULT_CERTITUDE_LIST_SIZE),
+                ("event_id", ctypes.c_ubyte * 16), ]
 
     def __init__(self,
                  bytes_descr=None,


### PR DESCRIPTION
An event ID has been added to Darwin to make it work in an asynchronous mode.

In order for the Darwin header to be still correctly parsed, the DarwinPacket class in darwinprotocol.py has been updated as well.