### PR TITLE
Add missing socket_type

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -103,6 +103,7 @@ def test_filter(filter_name, socket_type=None, socket_path=None, socket_host=Non
             elif socket_type == "tcp":
                 darwin_api = DarwinApi(socket_host=socket_host,
                                        socket_port=socket_port,
+                                       socket_type=socket_type,
                                        verbose=verbose, )
 
             else:


### PR DESCRIPTION
Add missing "socket_type" argument when calling the DPC with a TCP socket.