### PR TITLE
Add Body Reading of Darwin Response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Visual Studio Code
+.vscode


### PR DESCRIPTION
# :sparkles: Pull Request Template
:bangbang: Once all the **checklist** is **done** you have to:
  * **stash merge** this pull request
  * **delete** the corresponding **branch**
  * **close** the associated **issue**

## :page_with_curl: Type of change

**New feature**: non-breaking change which adds functionality.

## :bulb: Related Issue(s)

- Resolve #14 

## :black_nib: Description

Improving the protocol compliance:

Now reads the certitude list using the certitude_size attribute of the protocol structure.

Also reads the body of the response if given.
The body is only available from a `DarwinApi.low_level_call` for backward compatibility.

Added filter code of the yet to come filter `fsofa`.

## :dart: Test Environments

### FreeBSD 12.1
- Redis 5.0.7
- Boost 1.71.0
- clang++ 8.0.1
- CMake 3.15.3
- Python 3.6.9

### Ubuntu 19.4
- Redis 5.0.3
- Boost 1.71.0
- g++ 8.3.0
- CMake 3.13.4
- Python 3.7.3

## :heavy_check_mark: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

</br>

- [x] :raising_hand: **I certify on my honor that all the information provided is true, and I've done all I can to deliver a high quality code**
