### PR TITLE
ADD BODY READING FOR DARWIN RESPONSE (#15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Visual Studio Code
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="darwin",
-    version="1.0",
+    version="1.1",
     description="Call Darwin with your Python code!",
     url="https://github.com/VultureProject/darwin-client-python",
     author="Guillaume Catto",


### PR DESCRIPTION
# Changelog

## Improving Protocol Compliance

- Reads the certitude list using the certitude_size attribute of the protocol structure.
- Reads the body of the response if given. _The body is only available from a `DarwinApi.low_level_call` and `DarwinApi.bulk_call` for backward compatibility._
- Added filter code of the yet to come filter `fsofa`.