### PR TITLE
ADD IPV6 SUPPORT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="darwin",
-    version="1.2.1",
+    version="1.2.2",
     description="Call Darwin with your Python code!",
     url="https://github.com/VultureProject/darwin-client-python",
     author="Guillaume Catto",


### PR DESCRIPTION
Added 'tcp6' to socket types.
IPv6 must be set in the `socket_host` WITHOUT braces.